### PR TITLE
Configure Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,15 @@
+container:
+  image: cirrusci/android-sdk:26
+  cpu: 4
+  memory: 12G
+
+check_android_task:
+  gradle_cache:
+    folder: ~/.gradle/caches
+  android_cache:
+    folder: ~/.android/build-cache
+  check_script: ./gradlew check connectedCheck
+  codecov_script: curl -s https://codecov.io/bash | bash
+  cleanup_before_cache_script:
+    - rm -fr ~/.gradle/caches/4.*
+    - find ~/.gradle/caches/ -name "*.lock" -type f -delete

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,3 +28,4 @@ POM_DEVELOPER_ID=jacksgong
 POM_DEVELOPER_NAME=Jacksgong.com.
 
 org.gradle.parallel=true
+org.gradle.caching=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,17 @@
 rootProject.name = 'okdownload-root'
 
 include ':okdownload', ':okdownload-process', ':okdownload-connection-okhttp', ':okdownload-breakpoint-sqlite', ':okdownload-kotlin-enhance', ':benchmark', ':okdownload-filedownloader', 'sample'
+
+ext.isCiServer = System.getenv().containsKey("CI")
+ext.isMasterBranch = System.getenv()["CIRRUS_BRANCH"] == "master"
+
+buildCache {
+    local {
+        enabled = !isCiServer
+    }
+    remote(HttpBuildCache) {
+        url = 'http://' + System.getenv().getOrDefault("CIRRUS_HTTP_CACHE_HOST", "localhost:12321") + "/"
+        enabled = isCiServer
+        push = isMasterBranch
+    }
+}


### PR DESCRIPTION
Configured as described in https://cirrus-ci.org/examples/#android

Cirrus CI has first class support for build systems like Gradle by providing built-in HTTP Cache. This change enables Cirrus CI which is 2 times faster.

![image](https://user-images.githubusercontent.com/989066/35872266-63871d74-0b34-11e8-9aa4-657746dce389.png)

Feel free to close the PR if you are not going to change the current CI situation. In case of merging please don't forget to [install Cirrus CI](github.com/apps/cirrus-ci) on the repository before merging.