### PR TITLE
fix: cannot enqueue ended task instantly

### DIFF
--- a/okdownload/src/test/java/com/liulishuo/okdownload/core/dispatcher/DownloadDispatcherTest.java
+++ b/okdownload/src/test/java/com/liulishuo/okdownload/core/dispatcher/DownloadDispatcherTest.java
@@ -895,6 +895,84 @@ public class DownloadDispatcherTest {
         assertThat(pendingCalls.isEmpty()).isEqualTo(true);
     }
 
+    @Test
+    public void isRunning_async_true() {
+        final DownloadCall mockRunningCall = spy(DownloadCall.create(mockTask(), true, store));
+        runningAsyncCalls.add(mockRunningCall);
+        when(mockRunningCall.isCanceled()).thenReturn(false);
+
+        final boolean result = dispatcher.isRunning(mockRunningCall.task);
+
+        assertThat(result).isEqualTo(true);
+    }
+
+    @Test
+    public void isRunning_async_false() {
+        final DownloadCall mockRunningCall = spy(DownloadCall.create(mockTask(1), true, store));
+        runningAsyncCalls.add(mockRunningCall);
+
+        // because of cancelled
+        when(mockRunningCall.isCanceled()).thenReturn(true);
+
+        boolean result = dispatcher.isRunning(mockRunningCall.task);
+
+        assertThat(result).isEqualTo(false);
+
+        // because of no running task
+        runningAsyncCalls.clear();
+        when(mockRunningCall.isCanceled()).thenReturn(false);
+
+        result = dispatcher.isRunning(mockRunningCall.task);
+
+        assertThat(result).isEqualTo(false);
+
+        // because of the task is not in the running list
+        runningAsyncCalls.add(mockRunningCall);
+
+        result = dispatcher.isRunning(mockTask(2));
+
+        assertThat(result).isEqualTo(false);
+    }
+
+    @Test
+    public void isRunning_sync_true() {
+        final DownloadCall mockRunningCall = spy(DownloadCall.create(mockTask(), false, store));
+        runningSyncCalls.add(mockRunningCall);
+        when(mockRunningCall.isCanceled()).thenReturn(false);
+
+        final boolean result = dispatcher.isRunning(mockRunningCall.task);
+
+        assertThat(result).isEqualTo(true);
+    }
+
+    @Test
+    public void isRunning_sync_false() {
+        final DownloadCall mockRunningCall = spy(DownloadCall.create(mockTask(1), false, store));
+        runningSyncCalls.add(mockRunningCall);
+
+        // because of cancelled
+        when(mockRunningCall.isCanceled()).thenReturn(true);
+
+        boolean result = dispatcher.isRunning(mockRunningCall.task);
+
+        assertThat(result).isEqualTo(false);
+
+        // because of no running task
+        runningSyncCalls.clear();
+        when(mockRunningCall.isCanceled()).thenReturn(false);
+
+        result = dispatcher.isRunning(mockRunningCall.task);
+
+        assertThat(result).isEqualTo(false);
+
+        // because of the task is not in the running list
+        runningSyncCalls.add(mockRunningCall);
+
+        result = dispatcher.isRunning(mockTask(2));
+
+        assertThat(result).isEqualTo(false);
+    }
+
     private static class MockDownloadDispatcher extends DownloadDispatcher {
     }
 }


### PR DESCRIPTION
## 解决的问题：
一个 task 结束的回调要早于它从 `DownloadDispatcher` 里面的 `runningSyncCalls` 或者`runningAsyncCalls` 移除操作。如果在这个时间段启动同样的任务，会直接回调 warn 。

## 解决思路：
当启动一个 task 时，如果有同样的 task 在 runningXXX 列表里，那么把该任务从 runningXXX 列表中移除，然后添加到 `finishingCalls` 里，这样新启动的 task 可以正常进行，正在 finishing 的 task 也会在很短的时间内从 `finishingCalls` 内移除。
