### PR TITLE
refactor: Simplify the main logic - DownloadCall::execute

### DIFF
--- a/okdownload/src/main/java/com/liulishuo/okdownload/core/download/DownloadCall.java
+++ b/okdownload/src/main/java/com/liulishuo/okdownload/core/download/DownloadCall.java
@@ -259,7 +259,7 @@ public class DownloadCall extends NamedRunnable implements Comparable<DownloadCa
 
     private Exception realCauseOrNull(DownloadCache cache, EndCause cause) {
         if (cause == EndCause.ERROR || cause == EndCause.PRE_ALLOCATE_FAILED) {
-           return cache.getRealCause();
+            return cache.getRealCause();
         }
         return null;
     }

--- a/okdownload/src/main/java/com/liulishuo/okdownload/core/download/DownloadCall.java
+++ b/okdownload/src/main/java/com/liulishuo/okdownload/core/download/DownloadCall.java
@@ -233,21 +233,26 @@ public class DownloadCall extends NamedRunnable implements Comparable<DownloadCa
         if (canceled || cache == null) return;
 
         final EndCause cause;
-        Exception realCause = null;
         if (cache.isServerCanceled() || cache.isUnknownError()
                 || cache.isPreconditionFailed()) {
             // error
             cause = EndCause.ERROR;
-            realCause = cache.getRealCause();
         } else if (cache.isFileBusyAfterRun()) {
             cause = EndCause.FILE_BUSY;
         } else if (cache.isPreAllocateFailed()) {
             cause = EndCause.PRE_ALLOCATE_FAILED;
-            realCause = cache.getRealCause();
         } else {
             cause = EndCause.COMPLETED;
         }
+        Exception realCause = realCauseOrNull(cache, cause);
         inspectTaskEnd(cache, cause, realCause);
+    }
+
+    private Exception realCauseOrNull(DownloadCache cache, EndCause cause) {
+        if (cause == EndCause.ERROR || cause == EndCause.PRE_ALLOCATE_FAILED) {
+           return cache.getRealCause();
+        }
+        return null;
     }
 
     private void inspectTaskStart() {

--- a/okdownload/src/main/java/com/liulishuo/okdownload/core/download/DownloadCall.java
+++ b/okdownload/src/main/java/com/liulishuo/okdownload/core/download/DownloadCall.java
@@ -148,7 +148,7 @@ public class DownloadCall extends NamedRunnable implements Comparable<DownloadCa
 
     private void tryDownloadInLoop(OkDownload okDownload, ProcessFileStrategy fileStrategy) throws InterruptedException {
         int retryCount = 0;
-        while(true) {
+        while (true) {
             // 0. check basic param before start
             if (task.getUrl().length() <= 0) {
                 this.cache = new DownloadCache.PreError(

--- a/okdownload/src/main/java/com/liulishuo/okdownload/core/download/DownloadCall.java
+++ b/okdownload/src/main/java/com/liulishuo/okdownload/core/download/DownloadCall.java
@@ -147,9 +147,8 @@ public class DownloadCall extends NamedRunnable implements Comparable<DownloadCa
     }
 
     private void tryDownloadInLoop(OkDownload okDownload, ProcessFileStrategy fileStrategy) throws InterruptedException {
-        boolean retry;
         int retryCount = 0;
-        do {
+        while(true) {
             // 0. check basic param before start
             if (task.getUrl().length() <= 0) {
                 this.cache = new DownloadCache.PreError(
@@ -234,11 +233,10 @@ public class DownloadCall extends NamedRunnable implements Comparable<DownloadCa
             if (cache.isPreconditionFailed()
                     && retryCount++ < MAX_COUNT_RETRY_FOR_PRECONDITION_FAILED) {
                 store.remove(task.getId());
-                retry = true;
             } else {
-                retry = false;
+                break;
             }
-        } while (retry);
+        }
     }
 
     private EndCause getEndCause(DownloadCache cache) {

--- a/okdownload/src/main/java/com/liulishuo/okdownload/core/download/DownloadCall.java
+++ b/okdownload/src/main/java/com/liulishuo/okdownload/core/download/DownloadCall.java
@@ -232,6 +232,12 @@ public class DownloadCall extends NamedRunnable implements Comparable<DownloadCa
         final DownloadCache cache = this.cache;
         if (canceled || cache == null) return;
 
+        final EndCause cause = getEndCause(cache);
+        Exception realCause = realCauseOrNull(cache, cause);
+        inspectTaskEnd(cache, cause, realCause);
+    }
+
+    private EndCause getEndCause(DownloadCache cache) {
         final EndCause cause;
         if (cache.isServerCanceled() || cache.isUnknownError()
                 || cache.isPreconditionFailed()) {
@@ -244,8 +250,7 @@ public class DownloadCall extends NamedRunnable implements Comparable<DownloadCa
         } else {
             cause = EndCause.COMPLETED;
         }
-        Exception realCause = realCauseOrNull(cache, cause);
-        inspectTaskEnd(cache, cause, realCause);
+        return cause;
     }
 
     private Exception realCauseOrNull(DownloadCache cache, EndCause cause) {


### PR DESCRIPTION
**Problem:** The method `DownloadCall::execute()` is long and complex.
**Solution:** Refactor (keep functionality) -
Simplify the method, by extracting a few helper methods.
The structure of the main logic is kept consistent with the diagram at https://github.com/lingochamp/okdownload/blob/master/CONTRIBUTING.md

I work on semi-automatic refactoring pull requests.
If you want to help me help you, and you think this project will benefit from refactoring PRs, please click the link below.
[![Yes - I want a refactoring service](https://refactormachine.com/wp-content/uploads/2018/09/yes-e1537456577294.jpeg)](https://refactormachine.com/refactoring-pull-requests-yes/)
If this PR annoys you, please click on the link below, so I will stop doing it in other repos as well
[![No please - it annoys me](https://refactormachine.com/wp-content/uploads/2018/09/no-e1537456561421.jpeg)](https://refactormachine.com/free-refactoring-pull-requests-service-no/)
Assaf
