### PR TITLE
refactor (DownloadCall::execute): Simplify the method `execute`.

### DIFF
--- a/okdownload/src/main/java/com/liulishuo/okdownload/core/download/DownloadCall.java
+++ b/okdownload/src/main/java/com/liulishuo/okdownload/core/download/DownloadCall.java
@@ -146,7 +146,8 @@ public class DownloadCall extends NamedRunnable implements Comparable<DownloadCa
         inspectTaskEnd(cache, cause, realCause);
     }
 
-    private void tryDownloadInLoop(OkDownload okDownload, ProcessFileStrategy fileStrategy) throws InterruptedException {
+    private void tryDownloadInLoop(OkDownload okDownload, ProcessFileStrategy fileStrategy)
+            throws InterruptedException {
         int retryCount = 0;
         while (true) {
             // 0. check basic param before start
@@ -235,7 +236,8 @@ public class DownloadCall extends NamedRunnable implements Comparable<DownloadCa
         }
     }
 
-    private void downloadFromBeginning(ProcessFileStrategy fileStrategy, BreakpointInfo info, BreakpointRemoteCheck remoteCheck, ResumeFailedCause cause) throws IOException {
+    private void downloadFromBeginning(ProcessFileStrategy fileStrategy, BreakpointInfo info,
+                                       BreakpointRemoteCheck remoteCheck, ResumeFailedCause cause) throws IOException {
         fileStrategy.discardProcess(task);
         assembleBlockAndCallbackFromBeginning(info, remoteCheck,
                 cause);

--- a/okdownload/src/main/java/com/liulishuo/okdownload/core/download/DownloadCall.java
+++ b/okdownload/src/main/java/com/liulishuo/okdownload/core/download/DownloadCall.java
@@ -125,16 +125,30 @@ public class DownloadCall extends NamedRunnable implements Comparable<DownloadCa
     public void execute() throws InterruptedException {
         currentThread = Thread.currentThread();
 
-        boolean retry;
-        int retryCount = 0;
-
         // ready param
         final OkDownload okDownload = OkDownload.with();
         final ProcessFileStrategy fileStrategy = okDownload.processFileStrategy();
 
         // inspect task start
         inspectTaskStart();
-        do {
+
+        tryDownloadInLoop(okDownload, fileStrategy);
+
+        // finish
+        finishing = true;
+        blockChainList.clear();
+
+        final DownloadCache cache = this.cache;
+        if (canceled || cache == null) return;
+
+        final EndCause cause = getEndCause(cache);
+        Exception realCause = realCauseOrNull(cache, cause);
+        inspectTaskEnd(cache, cause, realCause);
+    }
+
+    private void tryDownloadInLoop(OkDownload okDownload, ProcessFileStrategy fileStrategy) throws InterruptedException {
+        int retryCount = 0;
+        while (true) {
             // 0. check basic param before start
             if (task.getUrl().length() <= 0) {
                 this.cache = new DownloadCache.PreError(
@@ -190,9 +204,7 @@ public class DownloadCall extends NamedRunnable implements Comparable<DownloadCa
                         Util.d(TAG, "breakpoint invalid: download from beginning because of "
                                 + "local check is dirty " + task.getId() + " " + localCheck);
                         // 6. assemble block data
-                        fileStrategy.discardProcess(task);
-                        assembleBlockAndCallbackFromBeginning(info, remoteCheck,
-                                localCheck.getCauseOrThrow());
+                        downloadFromBeginning(fileStrategy, info, remoteCheck, localCheck.getCauseOrThrow());
                     } else {
                         okDownload.callbackDispatcher().dispatch()
                                 .downloadFromBreakpoint(task, info);
@@ -201,9 +213,7 @@ public class DownloadCall extends NamedRunnable implements Comparable<DownloadCa
                     Util.d(TAG, "breakpoint invalid: download from beginning because of "
                             + "remote check not resumable " + task.getId() + " " + remoteCheck);
                     // 6. assemble block data
-                    fileStrategy.discardProcess(task);
-                    assembleBlockAndCallbackFromBeginning(info, remoteCheck,
-                            remoteCheck.getCauseOrThrow());
+                    downloadFromBeginning(fileStrategy, info, remoteCheck, remoteCheck.getCauseOrThrow());
                 }
             } catch (IOException e) {
                 cache.setUnknownError(e);
@@ -219,35 +229,37 @@ public class DownloadCall extends NamedRunnable implements Comparable<DownloadCa
             if (cache.isPreconditionFailed()
                     && retryCount++ < MAX_COUNT_RETRY_FOR_PRECONDITION_FAILED) {
                 store.remove(task.getId());
-                retry = true;
             } else {
-                retry = false;
+                break;
             }
-        } while (retry);
+        }
+    }
 
-        // finish
-        finishing = true;
-        blockChainList.clear();
+    private void downloadFromBeginning(ProcessFileStrategy fileStrategy, BreakpointInfo info, BreakpointRemoteCheck remoteCheck, ResumeFailedCause cause) throws IOException {
+        fileStrategy.discardProcess(task);
+        assembleBlockAndCallbackFromBeginning(info, remoteCheck,
+                cause);
+    }
 
-        final DownloadCache cache = this.cache;
-        if (canceled || cache == null) return;
-
-        final EndCause cause;
-        Exception realCause = null;
+    private EndCause getEndCause(DownloadCache cache) {
         if (cache.isServerCanceled() || cache.isUnknownError()
                 || cache.isPreconditionFailed()) {
             // error
-            cause = EndCause.ERROR;
-            realCause = cache.getRealCause();
+            return EndCause.ERROR;
         } else if (cache.isFileBusyAfterRun()) {
-            cause = EndCause.FILE_BUSY;
+            return EndCause.FILE_BUSY;
         } else if (cache.isPreAllocateFailed()) {
-            cause = EndCause.PRE_ALLOCATE_FAILED;
-            realCause = cache.getRealCause();
+            return EndCause.PRE_ALLOCATE_FAILED;
         } else {
-            cause = EndCause.COMPLETED;
+            return EndCause.COMPLETED;
         }
-        inspectTaskEnd(cache, cause, realCause);
+    }
+
+    private Exception realCauseOrNull(DownloadCache cache, EndCause cause) {
+        if (cause == EndCause.ERROR || cause == EndCause.PRE_ALLOCATE_FAILED) {
+            return cache.getRealCause();
+        }
+        return null;
     }
 
     private void inspectTaskStart() {


### PR DESCRIPTION
**Problem:** The method `DownloadCall::execute()` is long and complex.
**Solution:** Refactor the method.
Simplify the method, by extracting a few helper methods.
The structure of the main logic is kept consistent with the diagram at https://github.com/lingochamp/okdownload/blob/master/CONTRIBUTING.md

I work on semi-automatic refactoring pull requests.
If you want to help me help you, and you think this project will benefit from refactoring PRs, please click the link below.
[![Yes - I want a refactoring service](https://refactormachine.com/wp-content/uploads/2018/09/yes-e1537456577294.jpeg)](https://refactormachine.com/refactoring-pull-requests-yes/)
If this PR annoys you, please click on the link below, so I will stop doing it in other repos as well
[![No please - it annoys me](https://refactormachine.com/wp-content/uploads/2018/09/no-e1537456561421.jpeg)](https://refactormachine.com/free-refactoring-pull-requests-service-no/)
Assaf

