### PR TITLE
refactor (DownloadCall): Simplify the method DownloadCall::execute

### DIFF
--- a/okdownload/src/main/java/com/liulishuo/okdownload/core/download/DownloadCall.java
+++ b/okdownload/src/main/java/com/liulishuo/okdownload/core/download/DownloadCall.java
@@ -125,16 +125,31 @@ public class DownloadCall extends NamedRunnable implements Comparable<DownloadCa
     public void execute() throws InterruptedException {
         currentThread = Thread.currentThread();
 
-        boolean retry;
-        int retryCount = 0;
-
         // ready param
         final OkDownload okDownload = OkDownload.with();
         final ProcessFileStrategy fileStrategy = okDownload.processFileStrategy();
 
         // inspect task start
         inspectTaskStart();
-        do {
+
+        tryDownloadInLoop(okDownload, fileStrategy);
+
+        // finish
+        finishing = true;
+        blockChainList.clear();
+
+        final DownloadCache cache = this.cache;
+        if (canceled || cache == null) return;
+
+        final EndCause cause = getEndCause(cache);
+        Exception realCause = realCauseOrNull(cache, cause);
+        inspectTaskEnd(cache, cause, realCause);
+    }
+
+    private void tryDownloadInLoop(OkDownload okDownload, ProcessFileStrategy fileStrategy)
+            throws InterruptedException {
+        int retryCount = 0;
+        while (true) {
             // 0. check basic param before start
             if (task.getUrl().length() <= 0) {
                 this.cache = new DownloadCache.PreError(
@@ -219,35 +234,31 @@ public class DownloadCall extends NamedRunnable implements Comparable<DownloadCa
             if (cache.isPreconditionFailed()
                     && retryCount++ < MAX_COUNT_RETRY_FOR_PRECONDITION_FAILED) {
                 store.remove(task.getId());
-                retry = true;
             } else {
-                retry = false;
+                break;
             }
-        } while (retry);
+        }
+    }
 
-        // finish
-        finishing = true;
-        blockChainList.clear();
-
-        final DownloadCache cache = this.cache;
-        if (canceled || cache == null) return;
-
-        final EndCause cause;
-        Exception realCause = null;
+    private EndCause getEndCause(DownloadCache cache) {
         if (cache.isServerCanceled() || cache.isUnknownError()
                 || cache.isPreconditionFailed()) {
             // error
-            cause = EndCause.ERROR;
-            realCause = cache.getRealCause();
+            return EndCause.ERROR;
         } else if (cache.isFileBusyAfterRun()) {
-            cause = EndCause.FILE_BUSY;
+            return EndCause.FILE_BUSY;
         } else if (cache.isPreAllocateFailed()) {
-            cause = EndCause.PRE_ALLOCATE_FAILED;
-            realCause = cache.getRealCause();
+            return EndCause.PRE_ALLOCATE_FAILED;
         } else {
-            cause = EndCause.COMPLETED;
+            return EndCause.COMPLETED;
         }
-        inspectTaskEnd(cache, cause, realCause);
+    }
+
+    private Exception realCauseOrNull(DownloadCache cache, EndCause cause) {
+        if (cause == EndCause.ERROR || cause == EndCause.PRE_ALLOCATE_FAILED) {
+            return cache.getRealCause();
+        }
+        return null;
     }
 
     private void inspectTaskStart() {


### PR DESCRIPTION
**Problem**: The method DownloadCall::execute is long and complex.
**Solution**: Refactor the method.
Extract a helper method to perform the main logic in a loop `tryDownloadInLoop`.
Extract 2 helper methods to calculate `cause` and `realCause`.
Simplify the "retry" loop logic.
The structure of the main logic is kept consistent with the diagram at https://github.com/lingochamp/okdownload/blob/master/CONTRIBUTING.md

**Request for help**
I work on semi-automatic refactoring pull requests.
If you want to help me help you, and you think this project will benefit from refactoring PRs, please click the link below.
[![Yes - I want a refactoring service](https://refactormachine.com/wp-content/uploads/2018/09/yes-e1537456577294.jpeg)](https://refactormachine.com/refactoring-pull-requests-yes/)
If this PR annoys you, please click on the link below, so I will stop doing it in other repos as well
[![No please - it annoys me](https://refactormachine.com/wp-content/uploads/2018/09/no-e1537456561421.jpeg)](https://refactormachine.com/free-refactoring-pull-requests-service-no/)
Assaf

