### PR TITLE
修复空指针

### DIFF
--- a/okdownload/src/main/java/com/liulishuo/okdownload/core/listener/assist/Listener1Assist.java
+++ b/okdownload/src/main/java/com/liulishuo/okdownload/core/listener/assist/Listener1Assist.java
@@ -85,7 +85,7 @@ public class Listener1Assist implements ListenerAssist,
         final Listener1Model model = modelHandler.getOrRecoverModel(task, task.getInfo());
         if (model == null) return;
 
-        if (model.isFromResumed && model.isFirstConnect) {
+        if (model.isFromResumed != null && model.isFromResumed && model.isFirstConnect) {
             model.isFirstConnect = false;
         }
 


### PR DESCRIPTION
我们在fabric后台见到了约700次崩溃，目前版本约覆盖100万用户。只做了简单处理，因为：

1. isFromResumed，isFirstConnect标志并没有真正使用，所有不知道作用是什么；
2. 不想通过保证下载接口的调用时机修复。不应该依赖下载接口的调用时机，保证无空指针。

 model.onInfoValid(info) will not be invoked when info is null. Then
    model.isFromResumed hasn't been initialized.

log:
    Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.Boolean.booleanValue()' on a null object reference
       at com.liulishuo.okdownload.core.listener.assist.Listener1Assist.connectEnd(Listener1Assist.java:88)
       at com.liulishuo.okdownload.core.listener.DownloadListener1.connectEnd(DownloadListener1.java:91)