### PR TITLE
fix:close ParcelFileDescriptor

### DIFF
--- a/okdownload/src/main/java/com/liulishuo/okdownload/core/file/DownloadUriOutputStream.java
+++ b/okdownload/src/main/java/com/liulishuo/okdownload/core/file/DownloadUriOutputStream.java
@@ -69,6 +69,7 @@ public class DownloadUriOutputStream implements DownloadOutputStream {
     public void close() throws IOException {
         out.close();
         fos.close();
+        pdf.close();
     }
 
     @Override


### PR DESCRIPTION
pdf is Closeable , should close it when unuseful.