### PR TITLE
interrupt thread handled and interrupted not set 

### DIFF
--- a/okdownload/src/main/java/com/liulishuo/okdownload/core/NamedRunnable.java
+++ b/okdownload/src/main/java/com/liulishuo/okdownload/core/NamedRunnable.java
@@ -31,6 +31,7 @@ public abstract class NamedRunnable implements Runnable {
         try {
             execute();
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             interrupted(e);
         } finally {
             Thread.currentThread().setName(oldName);

--- a/okdownload/src/test/java/com/liulishuo/okdownload/core/exception/InterruptExceptionTest.java
+++ b/okdownload/src/test/java/com/liulishuo/okdownload/core/exception/InterruptExceptionTest.java
@@ -16,6 +16,8 @@
 
 package com.liulishuo.okdownload.core.exception;
 
+import com.liulishuo.okdownload.core.NamedRunnable;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -24,7 +26,8 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 
 public class InterruptExceptionTest {
 
-    @Rule public ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void printStackTrace() {
@@ -33,5 +36,35 @@ public class InterruptExceptionTest {
         thrown.expect(IllegalAccessError.class);
         thrown.expectMessage("Stack is ignored for signal");
         InterruptException.SIGNAL.printStackTrace();
+    }
+
+    @Test
+    public void testInterruptedStatus() {
+        Thread r1 = new Thread(new NamedRunnable("test runnable") {
+            @Override
+            protected void execute() throws InterruptedException {
+                Thread.sleep(1000);
+            }
+
+            @Override
+            protected void interrupted(InterruptedException e) {
+            }
+
+            @Override
+            protected void finished() {
+                if (!Thread.currentThread().isInterrupted()) {
+                    assertThat("").isEqualTo("Failed in get interrupted status");
+                }
+            }
+        });
+        r1.start();
+        try {
+            Thread.sleep(100);
+            r1.interrupt();
+            r1.join();
+        } catch (Exception e) {
+            assertThat("").isEqualTo("Failed in unknown exception");
+            e.printStackTrace();
+        }
     }
 }


### PR DESCRIPTION
Direct catching action in runnable, developers are unable to check interruption occurrence when do downloadtask.execute(), add 'interrupted' flag in interruption catch block to fix it.
refer to [this link ]( https://stackoverflow.com/questions/3976344/handling-interruptedexception-in-java#targetText=The%20InterruptedException%20is%20thrown%20when,the%20thread%20has%20been%20interrupted. )
