### PR TITLE
fix issue #415

### DIFF
--- a/okdownload/src/main/java/com/liulishuo/okdownload/core/file/MultiPointOutputStream.java
+++ b/okdownload/src/main/java/com/liulishuo/okdownload/core/file/MultiPointOutputStream.java
@@ -280,7 +280,11 @@ public class MultiPointOutputStream {
         final DownloadOutputStream outputStream = outputStreamMap.get(blockIndex);
         if (outputStream != null) {
             outputStream.close();
-            outputStreamMap.remove(blockIndex);
+            synchronized (noSyncLengthMap){
+                // make sure the length of noSyncLengthMap is equal to outputStreamMap
+                outputStreamMap.remove(blockIndex);
+                noSyncLengthMap.remove(blockIndex);
+            }
             Util.d(TAG, "OutputStream close task[" + task.getId() + "] block[" + blockIndex + "]");
         }
     }


### PR DESCRIPTION
When close the outputstrem, remove it from outputStreamMap but not remove it from noSyncLengthMap. That lead to syncRunnable crash cause java.lang.ArrayIndexOutOfBoundsException at function 'flushProcess' in class MultiPointOutputStream.java. The code is :

        synchronized (noSyncLengthMap) {
            // make sure the length of noSyncLengthMap is equal to outputStreamMap
            size = noSyncLengthMap.size();
        }

        final SparseArray<Long> increaseLengthMap = new SparseArray<>(size);

        try {
            for (int i = 0; i < size; i++) {
                final int blockIndex = outputStreamMap.keyAt(i);

The crash is at outputStreamMap.keyAt(i);

so when download at multiblock, and one of the outputstreams is close, the syncRunnable may crash, and will not do flushProces whitch update the currentOffset of blockInfo. 

finally it will throw exception at here. 

     public void inspectComplete(int blockIndex) throws IOException {
            final BlockInfo blockInfo = info.getBlock(blockIndex);
            if (!Util.isCorrectFull(blockInfo.getCurrentOffset(), blockInfo.getContentLength())) {
                throw new IOException("The current offset on block-info isn't update correct, "
                        + blockInfo.getCurrentOffset() + " != " + blockInfo.getContentLength()
                        + " on " + blockIndex);
            }
        }